### PR TITLE
MSSQL: encrypt-in-transit default for msodbcsql18 compatibility

### DIFF
--- a/plugins/login-akeyless-ssl.php
+++ b/plugins/login-akeyless-ssl.php
@@ -4,11 +4,23 @@ class AdminerAkeylessLoginSsl extends Adminer\Plugin {
 	function connectSsl() {
 		$auth = (isset($_POST["auth"]) && is_array($_POST["auth"]) ? $_POST["auth"] : array());
 		$sslMode = (isset($auth["ssl_mode"]) ? trim((string) $auth["ssl_mode"]) : "");
+		$driver = $this->currentDriver($auth);
+
+		// msodbcsql18 defaults an unset Encrypt to mandatory TLS with certificate
+		// validation, which breaks the default (no-SSL) path that connected plaintext
+		// under msodbcsql17. Always encrypt in transit; validate the server certificate
+		// only when the user opts into SSL mode, so existing connections stay reachable.
+		if ($driver == "mssql") {
+			return array(
+				"Encrypt" => true,
+				"TrustServerCertificate" => ($sslMode == ""),
+			);
+		}
+
 		if ($sslMode == "") {
 			return null;
 		}
 
-		$driver = $this->currentDriver($auth);
 		switch ($driver) {
 			case "pgsql":
 			case "postgres":
@@ -27,11 +39,6 @@ class AdminerAkeylessLoginSsl extends Adminer\Plugin {
 				return array(
 					"ca" => $ca,
 					"verify" => true,
-				);
-			case "mssql":
-				return array(
-					"Encrypt" => true,
-					"TrustServerCertificate" => false,
 				);
 		}
 


### PR DESCRIPTION
## Summary
Part of the SRA ARM64 effort ([ASM-18581](https://akeyless.atlassian.net/browse/ASM-18581)). The `zero-trust-bastion` Adminer stack must move `msodbcsql17` → `msodbcsql18` because **v17 has no arm64 packages**. msodbcsql18 changes the default for an unset `Encrypt` from `no` (plaintext) to `yes` with mandatory server-certificate validation — which would break every MSSQL connection on the default (no-SSL) path to a server without a CA-trusted cert.

This sets the MSSQL connection in the akeyless login plugin to **always encrypt in transit**, and to **validate the server cert only when the user opts into SSL mode**:

| Path | Before (msodbcsql17, unset) | After (msodbcsql18) |
|------|------|------|
| Default (no SSL selected) | plaintext | `Encrypt=true, TrustServerCertificate=true` — encrypted, no cert validation |
| SSL mode selected | `Encrypt=true, TrustServerCertificate=false` | unchanged (strict) |

Net effect: existing connections stay reachable (no cert-validation break) **and** get upgraded from plaintext to encrypted — a security gain, not just a compatibility patch. Approach chosen with the SRA lead over the alternatives (exact-v17 plaintext preserve vs. v18 strict-by-default).

## Delivery
`plugins/login-akeyless-ssl.php` ships standalone (not compiled into `adminer-5.4.2.php`), so this is the only file that changes. Once merged, this needs a **new tag** (e.g. `v5.4.2.2`); `zero-trust-bastion` then bumps its pinned adminer URLs to that tag alongside the `msodbcsql18` Dockerfile change.

## Verification
- [x] `php -l` clean
- [ ] End-to-end via zero-trust-bastion image (msodbcsql18): Adminer MSSQL login to a server **with** and **without** a trusted cert, default and SSL-mode paths, on amd64 and arm64 — covered in the companion ZTB PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ASM-18581]: https://akeyless.atlassian.net/browse/ASM-18581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ